### PR TITLE
Add resin temp to header bar

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -590,6 +590,7 @@ function update_status(){
 		}
 		update_timeline();
 		current_status_display();
+		$("#navbar-resin-temp").text(data['resin']);
 	}).fail(function() {
 		update_status.problem++;
 		if (update_status.problem>2){

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -590,7 +590,11 @@ function update_status(){
 		}
 		update_timeline();
 		current_status_display();
-		$("#navbar-resin-temp").text(data['resin']);
+
+		if (data['resin']) {
+			$('#navbar-resin-temp').show()
+			$("#navbar-resin-temp-text").text(data['resin']);
+		}
 	}).fail(function() {
 		update_status.problem++;
 		if (update_status.problem>2){

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -41,10 +41,10 @@
         {% if printerError %}
             <li><a class="svg error label label-danger" href="/printer">{{ icon(heart_icon) }}</a></li>
         {% endif %}
-        {% if os=="linux" %}
-        <li>
-            <a href="/printer"><small> Resin: <span id="navbar-resin-temp"></span>°C</small></a>
+        <li id="navbar-resin-temp" style="display:none">
+            <a href="/printer"><small> Resin: <span id="navbar-resin-temp-text"></span>°C</small></a>
         </li>
+        {% if os=="linux" %}
         <li>
             {% if wifi!="" %}
                 <a href="/wifi"><span class="label label-success">{{wifi}} &nbsp;<span class="glyphicon glyphicon-signal"></span></span></a>

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -43,7 +43,7 @@
         {% endif %}
         {% if os=="linux" %}
         <li>
-            <td id="resin"></td>
+            <a href="/printer"><small> Resin: <span id="navbar-resin-temp"></span>°C</small></a>
         </li>
         <li>
             {% if wifi!="" %}

--- a/templates/printer.html
+++ b/templates/printer.html
@@ -34,7 +34,7 @@
                     <td width="60px" translate>Proc</td>
                     <td width="40px" id="proc_numb">{{stat.ProcNumb}}</td>
                     <td width="60px" translate>Temp</td>
-                    <td width="40px" id="temp">{{stat.Temp}}</td>
+                    <td width="40px" id="temp">{{stat.Temp}}°C</td>
                 </tr>
                 <tr>
                     <td colspan=2 id="proc_chart" class="spark"><canvas></canvas></td>
@@ -56,7 +56,7 @@
                 </tr>
                 <tr>
                     <td translate>Resin</td>
-                    <td id="resin"></td>
+                    <td><span id="resin"></span>°C</td>
                 </tr>
                 <tr>
                     <td colspan=2 id="resin_chart" class="spark"><canvas></canvas></td>


### PR DESCRIPTION
# Description
Commonly requested feature on discord, adds the current resin temperature to the navbar. I've not been added to dev chat/clickup yet so this might be missing something important. Lmk your thoughts.

## Changes
- Navbar
  - Now shows current resin temperature as given by `/status` endpoint
  - Clicking on this resin temperature takes you to the status page
  - Navbar item isn't shown until the `/status` endpoint first reports data
- Status page
  - Adds degree symbols to the two temperatures given on the status page

## Screenshots
![image](https://github.com/pkElectronics/nanodlp-ui/assets/6642457/b51b7104-4903-4abd-b348-f540d2f2836d)
![image](https://github.com/pkElectronics/nanodlp-ui/assets/6642457/91c00108-f380-4bf3-9bcf-b8afcda1cd1a)
(Ignore the fact that temp is blank the resin chart is all over the place, I hacked in something locally to randomise my resin temperature for testing, and hadn't done the same on Temp)