### PR TITLE
Refactor: Cleanup and streamline analytics JS code

### DIFF
--- a/public/css/analytics.css
+++ b/public/css/analytics.css
@@ -1,0 +1,24 @@
+.u-legend.u-inline .u-value {
+    width: 150px;
+    text-align: left;
+}
+
+#uplot {
+    background-color: #BBB;
+}
+
+.u-label, .u-value, .u-title {
+    color: #000;
+}
+
+.u-legend.u-inline .u-value {
+    width: 100px;
+}
+
+.u-series {
+    font-size: small;
+}
+
+.uplot {
+    width: 100%;
+}

--- a/public/js/analytics.js
+++ b/public/js/analytics.js
@@ -1,0 +1,173 @@
+let dplot, plot;
+
+const ColourValues = [
+    "FF0000", "00FF00", "0000FF", "FFFF00", "FF00FF", "00FFFF", "000000",
+    "800000", "008000", "000080", "808000", "800080", "008080", "808080",
+    "C00000", "00C000", "0000C0", "C0C000", "C000C0", "00C0C0", "C0C0C0",
+    "400000", "004000", "000040", "404000", "400040", "004040", "404040",
+    "200000", "002000", "000020", "202000", "200020", "002020", "202020",
+    "600000", "006000", "000060", "606000", "600060", "006060", "606060",
+    "A00000", "00A000", "0000A0", "A0A000", "A000A0", "00A0A0", "A0A0A0",
+    "E00000", "00E000", "0000E0", "E0E000", "E000E0", "00E0E0", "E0E0E0",
+];
+
+function isNotAllNull(subArray) {
+    return subArray.some(element => element !== null);
+}
+
+function renderChart(name, dataRows, series) {
+
+    // Filter data and series if they are entirely null
+    const filteredData = dataRows.filter(isNotAllNull);
+    const filteredSeries = series.filter((_, index) => isNotAllNull(dataRows[index]));
+
+    let plotHeight = $(window).height() - 300;
+    if (plotHeight < 400) plotHeight = 400;
+    let opts = {
+        title: name,
+        id: "chart1",
+        class: "my-chart",
+        width: $("#uplot").innerWidth(),
+        height: plotHeight,
+        series: filteredSeries,
+        axes: prepareAxis(filteredSeries),
+    };
+    if ($("#uplot").html() != "") {
+        plot.setData(filteredData);
+        return;
+    }
+    $("#uplot").html("");
+    plot = new uPlot(opts, filteredData, $("#uplot")[0]);
+}
+
+function prepareAxis(series) {
+    let axes = [{}];
+    for (let seriesIdx = 1; seriesIdx < series.length; seriesIdx++) {
+        let scale = series[seriesIdx].scale;
+
+        const found = axes.some(axis => axis.scale === scale);
+
+        const decimalPlaces = determineDecimalPlaces(scale);
+
+        if (!found && decimalPlaces !== null) {
+            axes.push({
+                    labelSize: 15,
+                    gap: 0,
+                    size: 40,
+                    side: 3,
+                    grid: {show: false},
+                    label: scale,
+                    scale: scale,
+                    values: (self, ticks) => ticks.map(rawValue => rawValue.toFixed(decimalPlaces)),
+                }
+            )
+        }
+    }
+
+    let halfOfAxisCount = parseInt(axes.length / 2) + 1;
+    for (let j = halfOfAxisCount; j < axes.length; j++) {
+        axes[j].side = 1;
+    }
+    axes[1].grid.show = true;
+    return axes;
+}
+
+function determineDecimalPlaces(scale) {
+    let zeroPlaceScales = ["px", "Pressure"];
+    let onePlaceScales = ["s", "mm", "°C"];
+
+    if (zeroPlaceScales.includes(scale)) {
+        return 0;
+    } else if (onePlaceScales.includes(scale)) {
+        return 1;
+    } else {
+        return null;
+    }
+}
+
+function aggregateFunc(v, aggregate) {
+    let val = parseFloat(v / 1000000000);
+    if (aggregate == 0) return val;
+    return Math.round(val / aggregate) * aggregate;
+}
+
+function getSeries() {
+    let series = [{}];
+    $("#uplot").data("axes").forEach((element, key) => {
+        series.push({
+            show: true,
+            spanGaps: true,
+            label: element.Name,
+            scale: element.Type,
+            value: (self, rawValue) => (rawValue != null ? rawValue.toFixed(element.Decimal) + element.Type : ""),
+            stroke: "#" + ColourValues[key] + "88",
+            width: 1,
+        });
+    });
+    return series;
+}
+
+function downloadCSV(series, o) {
+    const a = document.createElement("a");
+    document.body.appendChild(a);
+    a.style = "display: none";
+    let p = "";
+    for (j = 0; j < series.length; j++) {
+        if (j == 0) {
+            p += "Timestamp,";
+        } else {
+            p += series[j].label + ",";
+        }
+    }
+    p += "\n\r";
+    let iT = o.length;
+    let jT = o[0].length
+    for (j = 0; j < jT; j++) {
+        for (i = 0; i < iT; i++) {
+            if (o[i][j] === null) p += ",";
+            else p += o[i][j] + ",";
+        }
+        p += "\n\r";
+    }
+    const blob = new Blob([p], {type: "octet/stream"}),
+        url = window.URL.createObjectURL(blob);
+    a.href = url;
+    a.download = "nanodlp.csv";
+    a.click();
+    window.URL.revokeObjectURL(url);
+}
+
+function buildChartFromData(name, dataResponse, exp) {
+    if (dataResponse.length === 0) {
+        return;
+    }
+
+    let series = getSeries();
+    let previousAggregateValue;
+    let dataPointIndex = 0;
+
+    // Fill processed data with empty arrays
+    let processedData = series.map(_serie => []);
+    let aggregate = $("#aggregate").val();
+
+    if (JSON.stringify(dplot) == JSON.stringify(dataResponse) && !exp) {
+        return
+    }
+    dplot = dataResponse;
+
+    dataResponse.forEach(responseItem => {
+        let currentAggregateValue = aggregateFunc(responseItem["ID"], aggregate);
+        if (currentAggregateValue != previousAggregateValue) {
+            for (j = 0; j < series.length; j++) {
+                processedData[j][dataPointIndex] = null;
+            }
+            processedData[0][dataPointIndex] = currentAggregateValue;
+            previousAggregateValue = currentAggregateValue;
+            dataPointIndex++;
+        }
+        processedData[responseItem["T"] + 1][dataPointIndex - 1] = responseItem["V"];
+    })
+
+    if (exp) return downloadCSV(series, processedData);
+    renderChart(name, processedData, series);
+}

--- a/templates/analytics-offline.html
+++ b/templates/analytics-offline.html
@@ -2,41 +2,12 @@
 {% block head %}
 <link rel="stylesheet" href="https://leeoniya.github.io/uPlot/dist/uPlot.min.css">
 <script src="https://leeoniya.github.io/uPlot/dist/uPlot.iife.min.js"></script>
-<style>
-    .u-legend.u-inline .u-value {
-        width: 150px;
-        text-align: left;
-    }
-    #uplot{
-        background-color: #BBB;
-    }
-    .u-label,.u-value,.u-title{
-        color:#000;
-    }
-    .u-legend.u-inline .u-value{
-        width: 100px;
-    }
-    .u-series{
-        font-size: small;
-    }
-    .uplot{
-        width:100%;
-    }
-</style>
+<script src='/static/js/analytics.js'></script>
+<link href='/static/css/analytics.css' rel="stylesheet">
+
 {% endblock %}
 {% block content %}
 <script>
-    var dplot,plot;
-    let ColourValues = [ 
-        "FF0000", "00FF00", "0000FF", "FFFF00", "FF00FF", "00FFFF", "000000", 
-        "800000", "008000", "000080", "808000", "800080", "008080", "808080", 
-        "C00000", "00C000", "0000C0", "C0C000", "C000C0", "00C0C0", "C0C0C0", 
-        "400000", "004000", "000040", "404000", "400040", "004040", "404040", 
-        "200000", "002000", "000020", "202000", "200020", "002020", "202020", 
-        "600000", "006000", "000060", "606000", "600060", "006060", "606060", 
-        "A00000", "00A000", "0000A0", "A0A000", "A000A0", "00A0A0", "A0A0A0", 
-        "E00000", "00E000", "0000E0", "E0E000", "E000E0", "00E0E0", "E0E0E0", 
-    ];    
     $(document).ready(function(){
         getData(false);
         $("#download-csv").click(function(){
@@ -45,133 +16,14 @@
         $("#file").change(function(){
             getData(false);
         });	
-	});    
-    function renderChart(data,series) {
-        // Remove null indicators
-        for (var i=data.length-1; i>0;i--){
-            var c = data[i].length;
-            for (var j=0; j<c;j++){
-                if (data[i][j]!=null){
-                    break;
-                }
-                if (j+1==c){
-                    data.splice(i,1);
-                    series.splice(i,1);
-                }
-            }
-        }
-        var plotHeight=$( window ).height()-300;
-        if (plotHeight<400) plotHeight=400;
-        let opts = {
-            title: "{{Name}}",
-            id: "chart1",
-            class: "my-chart",
-            width: $("#uplot").innerWidth(),
-            height: plotHeight,
-            series: series,
-            axes: prepareAxis(series),        
-        };
-        if ($("#uplot").html()!=""){
-            plot.setData(data);
-            return;
-        }
-        $("#uplot").html("");
-        plot = new uPlot(opts, data, $("#uplot")[0]);
-    }
-    function getData(exp){
-        var series = getSeries();
-        var t,p;
-        var i = 0;
-        let o = [];
+	});
+
+    function getData(exp) {
         var file = $("#file").val();
-        if (file=="") return
-        var aggregate = $("#aggregate").val();
-        $.getJSON("/analytic/file/"+file,function(d){
-            if (JSON.stringify(dplot)==JSON.stringify(d)&&!exp){
-                return
-            }
-            dplot=d;
-            for (j=0;j<series.length;j++){
-                o[j]=[];
-            }
-            $.each(d,function(k,v){
-                t = aggregateFunc(v["ID"],aggregate);
-                if (t!=p){
-                    for (j=0;j<series.length;j++){
-                        o[j][i]=null;
-                    }
-                    o[0][i]=t;
-                    p=t;
-                    i++;
-                }
-                o[v["T"]+1][i-1]=v["V"];
-            });
-            if (exp) return downloadCSV(series,o);
-            renderChart(o,series);
+        if (file == "") return
+        $.getJSON("/analytic/file/" + file, function (response) {
+            return buildChartFromData("{{Name}}", response, exp);
         });
-    }
-    function downloadCSV(s,o){
-        const a = document.createElement("a");
-        document.body.appendChild(a);
-        a.style = "display: none";
-        var v ="",p="";
-        for (j=0;j<s.length;j++){
-            if (j==0){
-                p+="Timestamp,";
-            } else {
-                p+=s[j].label+",";
-            }
-        }
-        p+="\n\r";
-        var iT=o.length;
-        var jT=o[0].length
-        for (j=0;j<jT;j++){
-            for (i=0;i<iT;i++){
-                if (o[i][j]===null) p+=",";
-                else p+=o[i][j]+",";
-            }
-            p+="\n\r";
-        }
-        const blob = new Blob([p], {type: "octet/stream"}),
-            url = window.URL.createObjectURL(blob);
-        a.href = url;
-        a.download = "nanodlp.csv";
-        a.click();
-        window.URL.revokeObjectURL(url);
-    }
-    function getSeries(){
-        var series = [{}];
-        $("#uplot").data("axes").forEach((element,key) => {
-            series.push({show: true,spanGaps: true,label: element.Name,scale: element.Type ,value: (self, rawValue) => (rawValue!=null?rawValue.toFixed(element.Decimal)+element.Type:""),stroke: "#"+ColourValues[key]+"88",width: 1,});
-        });
-        return series;
-    }
-    function aggregateFunc(v,ag){
-        var val = parseFloat(v/1000000000);
-        if (ag==0) return val;
-        return Math.round(val/ag)*ag;
-    }                
-    function prepareAxis(series){
-        var axes = [{}];
-        for (var i=1; i<series.length;i++){
-            var found = false;
-            var s = series[i];
-            for (var j=1; j<axes.length;j++){
-                if (s.scale==axes[j].scale){
-                    found = true;
-                }
-            }
-            if (!found&&(s.scale=="px"||s.scale=="Pressure")){
-                axes.push({label:s.scale,labelSize: 15,gap:0,size:40, scale:s.scale, values: (self, ticks) => ticks.map(rawValue => rawValue.toFixed(0)),side:3,grid:{show:false}});
-            } else if (!found&&(s.scale=="s"||s.scale=="mm"||s.scale=="°C")){
-                axes.push({label:s.scale,labelSize: 15,gap:0,size:40, scale:s.scale, values: (self, ticks) => ticks.map(rawValue => rawValue.toFixed(1)),side:3,grid:{show:false}});
-            }
-        }
-        for (var j=parseInt(axes.length/2)+1; j<axes.length;j++){
-            axes[j].side=1;
-        }
-        axes[1].grid.show=true;
-        return axes;
     }
 </script>
 <div id="uplot" data-axes='{{axes|safe}}'></div>

--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -2,182 +2,35 @@
 {% block head %}
 <link rel="stylesheet" href="https://leeoniya.github.io/uPlot/dist/uPlot.min.css">
 <script src="https://leeoniya.github.io/uPlot/dist/uPlot.iife.min.js"></script>
-<style>
-    .u-legend.u-inline .u-value {
-        width: 150px;
-        text-align: left;
-    }
-    #uplot{
-        background-color: #BBB;
-    }
-    .u-label,.u-value,.u-title{
-        color:#000;
-    }
-    .u-legend.u-inline .u-value{
-        width: 100px;
-    }
-    .u-series{
-        font-size: small;
-    }
-    .uplot{
-        width:100%;
-    }
-</style>
+<script src='/static/js/analytics.js'></script>
+<link href='/static/css/analytics.css' rel="stylesheet">
+
 {% endblock %}
 {% block content %}
 <script>
-    var dplot,plot;
-    let ColourValues = [ 
-        "FF0000", "00FF00", "0000FF", "FFFF00", "FF00FF", "00FFFF", "000000", 
-        "800000", "008000", "000080", "808000", "800080", "008080", "808080", 
-        "C00000", "00C000", "0000C0", "C0C000", "C000C0", "00C0C0", "C0C0C0", 
-        "400000", "004000", "000040", "404000", "400040", "004040", "404040", 
-        "200000", "002000", "000020", "202000", "200020", "002020", "202020", 
-        "600000", "006000", "000060", "606000", "600060", "006060", "606060", 
-        "A00000", "00A000", "0000A0", "A0A000", "A000A0", "00A0A0", "A0A0A0", 
-        "E00000", "00E000", "0000E0", "E0E000", "E000E0", "00E0E0", "E0E0E0", 
-    ];    
-    $(document).ready(function(){
-		waitForElement();
-	});    
-    function renderChart(data,series) {
-        // Remove null indicators
-        for (var i=data.length-1; i>0;i--){
-            var c = data[i].length;
-            for (var j=0; j<c;j++){
-                if (data[i][j]!=null){
-                    break;
-                }
-                if (j+1==c){
-                    data.splice(i,1);
-                    series.splice(i,1);
-                }
-            }
-        }
-        var plotHeight=$( window ).height()-300;
-        if (plotHeight<400) plotHeight=400;
-        let opts = {
-            title: "Sensor Reading",
-            id: "chart1",
-            class: "my-chart",
-            width: $("#uplot").innerWidth(),
-            height: plotHeight,
-            series: series,
-            axes: prepareAxis(series),        
-        };
-        if ($("#uplot").html()!=""){
-            plot.setData(data);
-            return;
-        }
-        $("#uplot").html("");
-        plot = new uPlot(opts, data, $("#uplot")[0]);
-    }
-    function waitForElement(){
-        if(typeof $ !== "undefined"){
+    $(document).ready(function () {
+        waitForElement();
+    });
+
+    function waitForElement() {
+        if (typeof $ !== "undefined") {
             getData(false);
             setInterval(function () {
-                if ($("#range").val()!="0") getData(false);
-            },1000);
-            $("#download-csv").click(function(){
+                if ($("#range").val() != "0") getData(false);
+            }, 1000);
+            $("#download-csv").click(function () {
                 getData(true);
-            });	
+            });
         } else {
             setTimeout(waitForElement, 250);
         }
     }
-    function getData(exp){
-        var series = getSeries();
-        var t,p;
-        var i = 0;
-        let o = [];
-        var range = $("#range").val();
-        var aggregate = $("#aggregate").val();
-        $.getJSON("/analytic/data/"+range,function(d){
-            if (JSON.stringify(dplot)==JSON.stringify(d)&&!exp){
-                return
-            }
-            dplot=d;
-            for (j=0;j<series.length;j++){
-                o[j]=[];
-            }
-            $.each(d,function(k,v){
-                t = aggregateFunc(v["ID"],aggregate);
-                if (t!=p){
-                    for (j=0;j<series.length;j++){
-                        o[j][i]=null;
-                    }
-                    o[0][i]=t;
-                    p=t;
-                    i++;
-                }
-                o[v["T"]+1][i-1]=v["V"];
-            });
-            if (exp) return downloadCSV(series,o);
-            renderChart(o,series);
+
+    function getData(exp) {
+        const range = $("#range").val();
+        $.getJSON("/analytic/data/" + range, function (response) {
+            return buildChartFromData("Sensor reading", response, exp)
         });
-    }
-    function downloadCSV(s,o){
-        const a = document.createElement("a");
-        document.body.appendChild(a);
-        a.style = "display: none";
-        var v ="",p="";
-        for (j=0;j<s.length;j++){
-            if (j==0){
-                p+="Timestamp,";
-            } else {
-                p+=s[j].label+",";
-            }
-        }
-        p+="\n\r";
-        var iT=o.length;
-        var jT=o[0].length
-        for (j=0;j<jT;j++){
-            for (i=0;i<iT;i++){
-                if (o[i][j]===null) p+=",";
-                else p+=o[i][j]+",";
-            }
-            p+="\n\r";
-        }
-        const blob = new Blob([p], {type: "octet/stream"}),
-            url = window.URL.createObjectURL(blob);
-        a.href = url;
-        a.download = "nanodlp.csv";
-        a.click();
-        window.URL.revokeObjectURL(url);
-    }
-    function getSeries(){
-        var series = [{}];
-        $("#uplot").data("axes").forEach((element,key) => {
-            series.push({show: true,spanGaps: true,label: element.Name,scale: element.Type ,value: (self, rawValue) => (rawValue!=null?rawValue.toFixed(element.Decimal)+element.Type:""),stroke: "#"+ColourValues[key]+"88",width: 1,});
-        });
-        return series;
-    }
-    function aggregateFunc(v,ag){
-        var val = parseFloat(v/1000000000);
-        if (ag==0) return val;
-        return Math.round(val/ag)*ag;
-    }                
-    function prepareAxis(series){
-        var axes = [{}];
-        for (var i=1; i<series.length;i++){
-            var found = false;
-            var s = series[i];
-            for (var j=1; j<axes.length;j++){
-                if (s.scale==axes[j].scale){
-                    found = true;
-                }
-            }
-            if (!found&&(s.scale=="px"||s.scale=="Pressure")){
-                axes.push({label:s.scale,labelSize: 15,gap:0,size:40, scale:s.scale, values: (self, ticks) => ticks.map(rawValue => rawValue.toFixed(0)),side:3,grid:{show:false}});
-            } else if (!found&&(s.scale=="s"||s.scale=="mm"||s.scale=="°C")){
-                axes.push({label:s.scale,labelSize: 15,gap:0,size:40, scale:s.scale, values: (self, ticks) => ticks.map(rawValue => rawValue.toFixed(1)),side:3,grid:{show:false}});
-            }
-        }
-        for (var j=parseInt(axes.length/2)+1; j<axes.length;j++){
-            axes[j].side=1;
-        }
-        axes[1].grid.show=true;
-        return axes;
     }
 </script>
 <div id="uplot" data-axes='{{axes|safe}}'></div>


### PR DESCRIPTION
## Description

Analytics code was mostly duplicated between `analytics.html` and `analytics-offline.html`. This PR pulls that shared logic out to a separate JS/CSS file and imports it so it's no longer duplicated. This will make it easier to maintain going forward, ensuring that bugs only need to be managed in one place.

Furthermore, the JS code for the analytics code was extremely hard to understand, with an abundance of single letter variable names and difficult looping logic. I've refactored this to try and be more readable, mostly by renaming variables but in some cases I have refactored code to use more modern JavaScript features that make it a lot more readable, such as `.forEach(...)`, `.filter(...)` and `.some(...)`. This code should behave identically to current master branch, but may be worth testing to ensure I've not broken anything along the way.

## Questions
- @shahinv Do the analytics graphs exist in the baseline nanodlp repo? If so, this commit may make it harder to bring things back in line. If that's the case I can change this PR to go into nanodlp and then merge it into this repo to avoid issues.
- @shahinv and @pkElectronics Do we have a minimum browser version we wish to support? All of the things I have introduced are considered widely available in all modern browsers. But may be worth considering an actual limit to browser support so it's easy to decide in future.
