### PR TITLE
fix issue with progress bar alt text reading ms instead of s

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -604,23 +604,25 @@ function update_status(){
 	});
 }
 
-function update_stat(){
+function update_stat() {
 	$.ajax({
-		url:'stat',
+		url: 'stat',
 		dataType: 'json',
 		type: 'GET',
 		timeout: 1200
-	}).done(function(data){
-		var total = 0;
-		var perc;
-		if (data===null) return;
-		$.each(data,function(k,v){
-			total+=v;
-		});
-		$.each(data,function(k,v){
-			perc=v*100/total;
-			$("#"+k).attr("title",$("#"+k).html()+": "+Math.floor(perc)+"% "+Math.floor(v/1000000000)+"s");
-			$("#"+k).width(perc+"%");
+	}).done(function (data) {
+		if (data === null) return;
+
+		const total = Object.values(data).reduce((sum, value) => sum + value, 0);
+		
+		Object.entries(data).forEach(([key, value]) => {
+			const percentage = Math.floor(value * 100 / total);
+			const statElem = $("#" + key);
+
+			const duration = (value / 1000000000000).toFixed(2);
+			statElem.attr("title", `${statElem.html()}: ${percentage}% ${duration}s`);
+
+			statElem.width(percentage + "%");
 		});
 	});
 }


### PR DESCRIPTION
# Description

Current alt text for the gcode progress bar shows the milliseconds as seconds
![image](https://github.com/pkElectronics/nanodlp-ui/assets/6642457/6f5599aa-f67c-45ef-a6a2-40de11d1a3b1)

This PR changes that, now showing the details in seconds rounded to two decimal places. I can't actually test this with a print on my branch wihtout a printer but the text will now show as
![image](https://github.com/pkElectronics/nanodlp-ui/assets/6642457/f759866f-15f7-4d94-a8bb-18a837d0a649)

I have also taken the time to refactor this to modern JS syntax.