### PR TITLE
Added dynamic lift and retract speeds to basic mode

### DIFF
--- a/public/js/athena.js
+++ b/public/js/athena.js
@@ -37,7 +37,28 @@ $("#setup2").submit(function(){
 	$("#PdEnableSimple").prop("checked", true);
 	$("#RlEnableSimple").prop("checked", true);
 	$("#DwEnableSimple").prop("checked", true);
+
+	const slowLiftSpeed = document.getElementById('SimpleSlowLiftSpeed').value;
+	const liftSpeed = document.getElementById('SimpleLiftSpeed').value;
+	const liftLayers = document.getElementById('SimpleSlowLiftLayers').value;
+	const slowRetractSpeed = document.getElementById('SimpleSlowRetractSpeed').value;
+	const retractSpeed = document.getElementById('SimpleRetractSpeed').value;
+	const retractLayers = document.getElementById('SimpleSlowRetractLayers').value;
+
+
+	saveSpeed(slowLiftSpeed, liftSpeed, liftLayers, $("#SimpleDynamicSpeed"))
+	saveSpeed(slowRetractSpeed, retractSpeed, retractLayers, $("#SimpleDynamicRetractSpeed"))
 });
+
+function saveSpeed(slowSpeed, fastSpeed, layers, formElement) {
+	const newConfigTextBlock = `[JS] if ([[LayerNumber]] < ${layers}) {
+    output = "${slowSpeed}";
+} else {
+    output = "${fastSpeed}";
+};[/JS]`;
+
+	formElement.prop('value', newConfigTextBlock)
+}
 
 $("#CdEnableSimple").change(function (){
 	cdEnable = $("#CdEnableSimple");
@@ -220,7 +241,43 @@ $("#BtnToggleHeater").click(function(){
 	
 });
 
+function convertDynamicSpeed(dynamicSpeed, fastElem, slowElem, layersElem ) {
+	const liftSpeedData = decodeHTMLEntities(dynamicSpeed);
+	const bottomSpeed = liftSpeedData.match(/< \d+\) {\s*output = "(\d+)";/);
+	const fastSpeed = liftSpeedData.match(/else {\s*output = "(\d+)";/);
+	const layers = liftSpeedData.match(/LayerNumber\]\] < (\d+)/);
 
+	if (fastSpeed) {
+		fastElem.value = fastSpeed[1];
+	}
+	if (bottomSpeed) {
+		slowElem.value = bottomSpeed[1];
+	}
+	if (layers) {
+		layersElem.value = layers[1];
+	}
+}
+
+function expertToSimpleElementConversion(dynamicLiftSpeed, dynamicRetractSpeed) {
+	convertDynamicSpeed(
+		dynamicLiftSpeed,
+		document.getElementById('SimpleLiftSpeed'),
+		document.getElementById('SimpleSlowLiftSpeed'),
+		document.getElementById('SimpleSlowLiftLayers')
+	);
+	convertDynamicSpeed(
+		dynamicRetractSpeed,
+		document.getElementById('SimpleRetractSpeed'),
+		document.getElementById('SimpleSlowRetractSpeed'),
+		document.getElementById('SimpleSlowRetractLayers')
+	);
+}
+
+function decodeHTMLEntities(text) {
+	const textArea = document.createElement('textarea');
+	textArea.innerHTML = text;
+	return textArea.value;
+}
 
 $(document).ready(function(){
 	cdEnable = $("#CdEnableSimple");

--- a/public/js/athena.js
+++ b/public/js/athena.js
@@ -50,6 +50,13 @@ $("#setup2").submit(function(){
 	saveSpeed(slowRetractSpeed, retractSpeed, retractLayers, $("#SimpleDynamicRetractSpeed"))
 });
 
+/**
+ * Translation layer for saving the dynamic speed values
+ * @param slowSpeed - The value of the slow speed as an integer
+ * @param fastSpeed - The value of the fast speed as an integer
+ * @param layers - The count of layers to save
+ * @param formElement - The Jquery input element from the expert mode form
+ */
 function saveSpeed(slowSpeed, fastSpeed, layers, formElement) {
 	const newConfigTextBlock = `[JS] if ([[LayerNumber]] < ${layers}) {
     output = "${slowSpeed}";
@@ -241,6 +248,13 @@ $("#BtnToggleHeater").click(function(){
 	
 });
 
+/**
+ * Conversion layer for the dynamic speed code blocks
+ * @param dynamicSpeed - The code block from the NanoDLP API
+ * @param fastElem - JQuery html input to store the fast speed in
+ * @param slowElem - JQuery html input to store the slow speed in
+ * @param layersElem - JQuery html input to store the layers in
+ */
 function convertDynamicSpeed(dynamicSpeed, fastElem, slowElem, layersElem ) {
 	const liftSpeedData = decodeHTMLEntities(dynamicSpeed);
 	const bottomSpeed = liftSpeedData.match(/< \d+\) {\s*output = "(\d+)";/);
@@ -258,6 +272,12 @@ function convertDynamicSpeed(dynamicSpeed, fastElem, slowElem, layersElem ) {
 	}
 }
 
+/**
+ * Acts as a translation layer between expert values from NanoDLP API into simple form values on the Basic Mode page
+ * Any form values that need to be translated to simpler values should be handled here
+ * @param dynamicLiftSpeed - NanoDLP DynamicSpeed code block
+ * @param dynamicRetractSpeed - NanoDLP DynamicRetractSpeed code block
+ */
 function expertToSimpleElementConversion(dynamicLiftSpeed, dynamicRetractSpeed) {
 	convertDynamicSpeed(
 		dynamicLiftSpeed,
@@ -273,6 +293,9 @@ function expertToSimpleElementConversion(dynamicLiftSpeed, dynamicRetractSpeed) 
 	);
 }
 
+/*
+	Hack to decode NanoDLP safe values
+ */
 function decodeHTMLEntities(text) {
 	const textArea = document.createElement('textarea');
 	textArea.innerHTML = text;

--- a/templates/profile/edit.html
+++ b/templates/profile/edit.html
@@ -623,8 +623,6 @@
 				const retractSpeed = `{{profile.DynamicRetractSpeed}}`;
 				expertToSimpleElementConversion(liftSpeed, retractSpeed)
 			});
-
-
 		</script>
 
 

--- a/templates/profile/edit.html
+++ b/templates/profile/edit.html
@@ -815,29 +815,29 @@
 					<div class="row">
 						<div class="col-md-3 i_basic i_option" style="padding-left: 0px;">
 							<label for="SimpleSlowLiftLayers">Slow Lift Layers</label>
-							<input class="form-control" name="SimpleSlowLiftLayers" id="SimpleSlowLiftLayers" type="number" required min="1">
+							<input class="form-control" name="SimpleSlowLiftLayers" id="SimpleSlowLiftLayers" type="number" required min="1" max="20">
 						</div>
 						<div class="col-md-3 i_basic i_option" style="padding-left: 0px;">
 							<label for="SimpleSlowLiftSpeed">Slow Lift Speed (um/s)</label>
-							<input class="form-control" name="SimpleSlowLiftSpeed" id="SimpleSlowLiftSpeed" type="number" required min="1">
+							<input class="form-control" name="SimpleSlowLiftSpeed" id="SimpleSlowLiftSpeed" type="number" required min="50" max="70">
 						</div>
 						<div class="col-md-3 i_basic i_option" style="padding-left: 0px;">
 							<label for="SimpleLiftSpeed">Lift Speed (um/s)</label>
-							<input class="form-control" name="SimpleLiftSpeed" id="SimpleLiftSpeed" type="number" required min="1">
+							<input class="form-control" name="SimpleLiftSpeed" id="SimpleLiftSpeed" type="number" required min="50" max="250">
 						</div>
 					</div>
 					<div class="row">
 						<div class="col-md-3 i_basic i_option" style="padding-left: 0px;">
 							<label for="SimpleSlowRetractLayers">Slow Retract Layers</label>
-							<input class="form-control" name="SimpleSlowRetractLayers" id="SimpleSlowRetractLayers" type="number" required min="1">
+							<input class="form-control" name="SimpleSlowRetractLayers" id="SimpleSlowRetractLayers" type="number" required min="1" max="20">
 						</div>
 						<div class="col-md-3 i_basic i_option" style="padding-left: 0px;">
 							<label for="SimpleSlowRetractSpeed">Slow Retract Speed (um/s)</label>
-							<input class="form-control" name="SimpleSlowRetractSpeed" id="SimpleSlowRetractSpeed" type="number" required min="1">
+							<input class="form-control" name="SimpleSlowRetractSpeed" id="SimpleSlowRetractSpeed" type="number" required min="50" max="600">
 						</div>
 						<div class="col-md-3 i_basic i_option" style="padding-left: 0px;">
 							<label for="SimpleRetractSpeed">Retract Speed (um/s)</label>
-							<input class="form-control" name="SimpleRetractSpeed" id="SimpleRetractSpeed" type="number" required min="1">
+							<input class="form-control" name="SimpleRetractSpeed" id="SimpleRetractSpeed" type="number" required min="50" max="600">
 						</div>
 					</div>
 				</div>

--- a/templates/profile/edit.html
+++ b/templates/profile/edit.html
@@ -837,7 +837,7 @@
 						</div>
 						<div class="col-md-3 i_basic i_option" style="padding-left: 0px;">
 							<label for="SimpleRetractSpeed">Retract Speed (um/s)</label>
-							<input class="form-control" name="SimpleRetractSpeed" id="SimpleRetractSpeed" type="number" required min="50" max="600">
+							<input class="form-control" name="SimpleRetractSpeed" id="SimpleRetractSpeed" type="number" required min="100" max="600">
 						</div>
 					</div>
 				</div>

--- a/templates/profile/edit.html
+++ b/templates/profile/edit.html
@@ -616,7 +616,19 @@
 </div>
 	<!-- ************************** ATHENA SIMPLE RESIN PAGE -->
 	<div id="setup-profile2">
-	<form action="" method="post" class="edit-page {% if viewMode == 1 %}hidden{% endif %}" id="setup2">
+
+		<script>
+			$(document).ready(() => {
+				const liftSpeed = `{{profile.DynamicSpeed}}`;
+				const retractSpeed = `{{profile.DynamicRetractSpeed}}`;
+				expertToSimpleElementConversion(liftSpeed, retractSpeed)
+			});
+
+
+		</script>
+
+
+		<form action="" method="post" class="edit-page {% if viewMode == 1 %}hidden{% endif %}" id="setup2">
 		<div class="row flex-row" id="options">
 			<div class="col-md-12 i_basic i_option">
 					<h3><span translate>Details</span>
@@ -797,6 +809,42 @@
 				</div>
 			</div>
 
+			<div class="col-md-12 i_basic i_option">
+				<div class="col-md-6 i_basic i_option" style="padding-left: 0px;">
+					<h5><span translate><strong>Lift / Retract Options</strong></span></h5>
+				</div>
+				<div class="col-md-12 i_basic i_option" style="padding-top:5px;">
+					<div class="row">
+						<div class="col-md-3 i_basic i_option" style="padding-left: 0px;">
+							<label for="SimpleSlowLiftLayers">Slow Lift Layers</label>
+							<input class="form-control" name="SimpleSlowLiftLayers" id="SimpleSlowLiftLayers" type="number" required min="1">
+						</div>
+						<div class="col-md-3 i_basic i_option" style="padding-left: 0px;">
+							<label for="SimpleSlowLiftSpeed">Slow Lift Speed (um/s)</label>
+							<input class="form-control" name="SimpleSlowLiftSpeed" id="SimpleSlowLiftSpeed" type="number" required min="1">
+						</div>
+						<div class="col-md-3 i_basic i_option" style="padding-left: 0px;">
+							<label for="SimpleLiftSpeed">Lift Speed (um/s)</label>
+							<input class="form-control" name="SimpleLiftSpeed" id="SimpleLiftSpeed" type="number" required min="1">
+						</div>
+					</div>
+					<div class="row">
+						<div class="col-md-3 i_basic i_option" style="padding-left: 0px;">
+							<label for="SimpleSlowRetractLayers">Slow Retract Layers</label>
+							<input class="form-control" name="SimpleSlowRetractLayers" id="SimpleSlowRetractLayers" type="number" required min="1">
+						</div>
+						<div class="col-md-3 i_basic i_option" style="padding-left: 0px;">
+							<label for="SimpleSlowRetractSpeed">Slow Retract Speed (um/s)</label>
+							<input class="form-control" name="SimpleSlowRetractSpeed" id="SimpleSlowRetractSpeed" type="number" required min="1">
+						</div>
+						<div class="col-md-3 i_basic i_option" style="padding-left: 0px;">
+							<label for="SimpleRetractSpeed">Retract Speed (um/s)</label>
+							<input class="form-control" name="SimpleRetractSpeed" id="SimpleRetractSpeed" type="number" required min="1">
+						</div>
+					</div>
+				</div>
+			</div>
+
 			<!-- Slicer Options -->
 			<div class="col-md-12 i_basic i_option" style="padding-top:10px;">
 				<div class="col-md-6 i_basic i_option" style="padding-left: 0px;">
@@ -886,8 +934,8 @@
 		</div>
 		</div>
 		<input type="hidden" value="{{profile.Color}}" name="Color">
-		<input type="hidden" value="{{profile.DynamicSpeed}}" name="DynamicSpeed">
-		<input type="hidden" value="{{profile.DynamicRetractSpeed}}" name="DynamicRetractSpeed">
+		<input type="hidden" value="{{profile.DynamicSpeed}}" name="DynamicSpeed" id="SimpleDynamicSpeed">
+		<input type="hidden" value="{{profile.DynamicRetractSpeed}}" name="DynamicRetractSpeed" id="SimpleDynamicRetractSpeed">
 		<input type="hidden" value="{{profile.LiftSpeed}}" name="LiftSpeed">
 		<input type="hidden" value="{{profile.RetractSpeed}}" name="RetractSpeed">
 		<input type="hidden" value="{{profile.ShieldDuringCure}}" name="ShieldDuringCure">


### PR DESCRIPTION
Adds a translation layer between expert and basic mode to provide inputs on the basic mode screen for the DynamicLift / DynamicRetract code.

This code:
- Pulls the current values for the resin profile from NanoDLP templating API
- Uses regex to parse the layer count, slow speed, fast speed and write them to some new form inputs on the Basic mode page
- On form submission, grab the values from the new form inputs and write them back into the dynamic values template, then write those values to the Expert mode input and save.

![image](https://github.com/user-attachments/assets/805f641e-f847-435a-a8f0-55f8af16795f)
