### PR TITLE
WUI-033 - Pause chart auto-update on zoom

### DIFF
--- a/public/js/analytics.js
+++ b/public/js/analytics.js
@@ -82,6 +82,7 @@ function renderChart(name, dataRows, series, uplotId) {
         return;
     }
 
+    $uplot.html('');
     opts = applyLegend(opts, uplotId);
     const newUplot = new uPlot(opts, dataRows, $uplot[0]);
     uplots.push({ id: uplotId, uplot: newUplot, seriesLength: series.length });

--- a/public/js/analytics.js
+++ b/public/js/analytics.js
@@ -1,6 +1,8 @@
 let cachedData;
 
 let uplots = [];
+
+// Used primarily for pausing the chart auto-update on zoom
 let isZoomed = false;
 
 const LOCAL_STORAGE_KEY = "legends:v2";
@@ -77,6 +79,7 @@ function renderChart(name, dataRows, series, uplotId) {
         hooks: {
             setSelect: [
                 _ => {
+                    // Chart has been zoomed in
                     isZoomed = true;
                     $('#chart-paused-warning').show()
                 }

--- a/public/js/analytics.js
+++ b/public/js/analytics.js
@@ -1,6 +1,7 @@
 let cachedData;
 
 let uplots = [];
+let isZoomed = false;
 
 const LOCAL_STORAGE_KEY = "legends:v2";
 
@@ -72,11 +73,38 @@ function renderChart(name, dataRows, series, uplotId) {
             sync: {
                 key: 'chartCursorSync'
             }
+        },
+        hooks: {
+            setSelect: [
+                _ => {
+                    isZoomed = true;
+                    $('#chart-paused-warning').show()
+                }
+            ],
+            setScale: [
+                (u, scale) => {
+                    // hack to determine if zoom has been reset, see https://github.com/leeoniya/uPlot/issues/565
+                    if (scale === 'x') {
+                        const { min, max } = u.scales.x;
+                        const xData = u.data[0];
+
+                        if (min === xData[0] && max === xData[xData.length - 1]) {
+                            isZoomed = false
+                            $('#chart-paused-warning').hide()
+                        }
+                    }
+                }
+            ]
         }
     };
 
+    if (isZoomed) {
+        return;
+    }
+
     const plotToUpdate = uplots.find(plot => plot.id === uplotId);
     if (plotToUpdate && plotToUpdate.seriesLength === series.length) {
+
         // Chart already exists, update the data and return so we don't rebuilt the whole HTML
         plotToUpdate.uplot.setData(dataRows);
         return;

--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -26,9 +26,9 @@
         }
     }
 
-    var reqRunning;
+    let reqRunning;
     function getData(exp) {
-        if (reqRunning===true) return;
+        if (reqRunning) return;
         reqRunning = true;
         const range = $("#range").val();
 
@@ -48,7 +48,7 @@
 <div class="row">
     <div class="col-xs-6 col-xs-offset-3">
         <div style="align-content: center; display: none" class="alert alert-info" id="chart-paused-warning">
-            <strong>Chart refresh is paused whilst zoomed in.</strong> double click to undo zoom
+            <strong>Chart auto update is paused whilst zoomed in.</strong> double click to reset zoom
         </div>
     </div>
 </div>

--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -42,9 +42,16 @@
         });
     }
 </script>
+
 <div id="uplot-1" class="uplot uplot-container"></div>
 <div id="uplot-2" class="uplot uplot-container"></div>
-<br>
+<div class="row">
+    <div class="col-xs-6 col-xs-offset-3">
+        <div style="align-content: center; display: none" class="alert alert-info" id="chart-paused-warning">
+            <strong>Chart refresh is paused whilst zoomed in.</strong> double click to undo zoom
+        </div>
+    </div>
+</div>
 <a class="btn btn-warning" href="/analytic/reset" translate>Reset Stats</a>
 <select id="range" class="form-control form-inline" style="display:inline;width: auto;">
     <option value="start" selected="selected" translate>Start of The Print - Auto Update</option>


### PR DESCRIPTION
- Adds a global var that tracks state whether the charts have been zoomed in or not
- Change the analytics.js to stop uplot updates on new data coming in or not
  - Ideally this would have actually stopped the requests being made to the analytics, however that state exists outside of the analytic js and it would be far too hacky to try and interact with it
- Adds a bootstrap info bubble that informs the user of the pause/zoom state and how to exit it