### PR TITLE
Add polling for success/failure on ticket submission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ nanodlp.exe.bak
 .idea/
 templates/nextion
 public/editor
+public/tickets

--- a/public/css/athena.css
+++ b/public/css/athena.css
@@ -150,14 +150,22 @@ a.list-group-item {
 .edit-page input,
 .edit-page select,
 .edit-page textarea,
+.support-form input,
 #search {
   background-color: #3b3b3b; !important;
   border: 1px solid #dddddd;
   border-radius: 0px;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  margin-bottom: 4px;
 }
 
-.edit-page textarea {
+.edit-page textarea,
+.support-form textarea {
   color: #f5f5f5;
+  height: 133px;
+}
+
+.toast-top-center {
+  margin-top: 16px !important;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -204,6 +204,8 @@
 	<script src='/static/js/slicer.js'></script>
 	<script src='/static/js/preview.js'></script>
 	<script src='/static/js/po.js'></script>
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css">
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
 	<script>if (window.module) module = window.module;</script>
 	<script src='/static/js/athena.js?{{version}}(athenav7)'></script>
 	{% block js %} {% endblock %} {% block tail %} {% endblock %}

--- a/templates/setup/support.html
+++ b/templates/setup/support.html
@@ -22,89 +22,40 @@
 </div>
 
 <div class="starter-template">
-    <div class="row flex-row">
-        <div class="col-md-12">
-            <h2 translate>Support Resources</h2>
+	<div class="row flex-row">
+		<div class="col-md-12">
+			<h2 translate>Support Resources</h2>
 		</div>
 	</div>
-    <div class="row flex-row">
+	<div class="row flex-row">
 		<div class="col-md-4">
 			<center>
-		
-            <h3 translate>Questions or up for a Chat? </br>Join our Discord</h3>
-			<br>
-            <a href="https://discord.gg/55wshXG7pp" target="_blank" translate><img width="15%" src="https://olymp.concepts3d.eu/static/athena-discord.png"></img></a>
-			</center>
-		</div>
-		<div class="col-md-4">
-			<center>
-				<h3 translate>Manual and Getting started</h3>
+				<h4 translate>Questions? </br>Join our Discord</h4>
 				<br>
-				<a href="https://www.concepts3d.ca/support" target="_blank" translate>www.concepts3d.ca/support</a>
+				<a href="https://discord.gg/55wshXG7pp" target="_blank" translate>discord.gg/55wshXG7pp</a>
+				<br>
+				<br>
+				<a href="https://discord.gg/55wshXG7pp" target="_blank" translate><img width="15%"
+																					   src="https://olymp.concepts3d.eu/static/athena-discord.png"
+																					   alt="A QR Code linking to Discord"/></a>
 			</center>
 		</div>
 		<div class="col-md-4">
-		<center>
-            <h3 translate>Reach out to our support Team</h3>
-			<br>
-            <a href="mailto:support@concepts3d.ca" target="_blank" translate>support@concepts3d.ca</a>
+			<center>
+				<h4 translate>Manual and Getting started</h4>
+				<br>
+				<a href="https://help.concepts3d.ca" target="_blank" translate>help.concepts3d.ca</a>
 			</center>
-		</div>	
+		</div>
+		<div class="col-md-4">
+			<center>
+				<h4 translate>Reach out to our support Team</h4>
+				<br>
+				<a href="mailto:support@concepts3d.ca" target="_blank" translate>support@concepts3d.ca</a>
+			</center>
+		</div>
 	</div>
 		<br>
-	<br>
-	<br>
-	<br>
-
-    <div class="row flex-row">
-		<div class="col-md-12">
-			<center>
-				<h2 translate>Shop for Upgrades, Spares and Consumables</h2>
-			</center>
-		</div>
-	</div>
-    <div class="row flex-row">
-
-		<div class="col-md-4 mapcontainer">
-			<a href="https://concepts3d.ca" target="_blank">
-				<div id="container">
-					<img class="bottom" src="static/shots/america-blur.png" />
-					<img class="top" src="static/shots/america-clear.png" />
-					<div class="maps-text">Americas</div>
-				</div>
-			</a>
-		</div>	
-		<div class="col-md-4 mapcontainer">
-			<a href="https://concepts3d.eu" target="_blank">
-				<div id="container">	
-					<img class="bottom" src="static/shots/europe-blur.png" />
-					<img class="top" src="static/shots/europe-clear.png" />
-					<div class="maps-text">Europe</div>
-
-				</div>
-			</a>
-		</div>		
-		<div class="col-md-4 mapcontainer">
-			<a href="https://concepts3d.ca" target="_blank">
-				<div id="container">
-					<img class="bottom" src="static/shots/asia-blur.png" />
-					<img class="top" src="static/shots/asia-clear.png" />
-					<div class="maps-text">Asia - Pacific</div>
-				</div>
-			</a>
-		</div>
-	</div>
-	<br>
-	<br>
-	<br>
-    <div class="row">	
-	    <div class="col-md-12">
-			<a href="https://www.vecteezy.com/free-vector/low-poly-world-map" style="text-size:6px" >Low Poly World Map Vectors by Vecteezy</a>
-		</div>
-	</div>
-	<br>
-	<br>
-	<br>
 	<br>
 	<br>
     <div class="row flex-row">
@@ -115,7 +66,7 @@
             <p translate>Please provide your name and email address so we can reach out to you.</p>                    
             <p translate>By submitting the form you agree that your printer configuration and log files will be transmitted to a server operated by Concepts3D or it's affiliates.</p>                    
             <p translate>You will receive a confirmation email where you can download the data that has been submitted for your own validation.</p>                    
-            <form class="edit-page" id="SupportForm">
+            <form class="support-form" id="SupportForm">
                 <input id="SupportNameField" class="form-control" name="name" type="name" placeholder="Your Name" required>
                 <input id="SupportEmailField" class="form-control" name="email" type="email" placeholder="Email address" required>
 				<textarea id="SupportTextField" class="form-control" name="report" placeholder="Detail of the bug you want to report." required></textarea>


### PR DESCRIPTION
Adds the frontend component of the ticket submission screen

Changes:
- On ticket submission, frontend now provides the timestamp of the ticket
- On ticket submission, frontend will poll every second for 30 seconds for the backend to write to `public/tickets/{{ticketTimestamp}}`
- Introduce a toast notification library
- A bunch of updates for the support screen

![image](https://github.com/user-attachments/assets/30519ed7-d2fe-4dff-9e54-83ae33813d51)
![image](https://github.com/user-attachments/assets/7b4505f2-39ce-40f7-86e5-6d44e5d1c624)
![image](https://github.com/user-attachments/assets/b438ed2a-f0b8-4146-bbe4-c4299dcacd6a)
