### PR TITLE
Remove ManufacturerLock input from edit form on clone page

### DIFF
--- a/templates/profile/edit.html
+++ b/templates/profile/edit.html
@@ -838,7 +838,6 @@
 		<input type="hidden" value="{{profile.XYResPerc}}" name="XYResPerc" id="XYResPerc">
 		<input type="hidden" name="UpdateCustomInput" value="true">
 		<input type="hidden" name="Type" value="{{profile.Type}}">
-		<input type="hidden" name="ManufacturerLock" value="{{profile.ManufacturerLock}}">
 		{{ customInputs(inputs,profile.CustomValues,1)}}
 		<button type="submit" class="btn btn-success" translate>Save</button> &nbsp;
 	</form>


### PR DESCRIPTION
This was only present on the export form, but it would always match the profile being cloned - meaning that if you clone a manufacturer locked profile in export mode the new profile would also be locked. Basic mode this issue wasn't present because the form didn't set that value in a hidden field.

I didn't see any way to detect the page and I can't edit the parent flask app so I decided it is best to just remove the line. It was added in 3b8144afa782f850e7eb3dd516dbb78dbe244fa5 as part of some manufacturer profile locking.